### PR TITLE
when the proxy protocol command is LOCAL the transport should be UNSPEC

### DIFF
--- a/v2.go
+++ b/v2.go
@@ -82,7 +82,9 @@ func parseVersion2(reader *bufio.Reader) (header *Header, err error) {
 	}
 	header.TransportProtocol = AddressFamilyAndProtocol(b14)
 	if _, ok := supportedTransportProtocol[header.TransportProtocol]; !ok {
-		return nil, ErrUnsupportedAddressFamilyAndProtocol
+		if !(header.Command.IsLocal() && header.TransportProtocol == UNSPEC) {
+			return nil, ErrUnsupportedAddressFamilyAndProtocol
+		}
 	}
 
 	// Make sure there are bytes available as specified in length

--- a/v2_test.go
+++ b/v2_test.go
@@ -136,6 +136,19 @@ var validParseAndWriteV2Tests = []struct {
 			DestinationPort:    0,
 		},
 	},
+	// LOCAL UNSPEC
+	{
+		newBufioReader(append(append(SIGV2, LOCAL, UNSPEC), fixtureIPv4V2...)),
+		&Header{
+			Version:            2,
+			Command:            LOCAL,
+			TransportProtocol:  UNSPEC,
+			SourceAddress:      nil,
+			DestinationAddress: nil,
+			SourcePort:         0,
+			DestinationPort:    0,
+		},
+	},
 	// PROXY TCP IPv4
 	{
 		newBufioReader(append(append(SIGV2, PROXY, TCPv4), fixtureIPv4V2...)),


### PR DESCRIPTION
The protocol specifies that the command should be UNSPEC, however AWS send the LOCAL proxy protocol as TCPV4, so we still attempt to validate transport but also check for LOCAL and UNSPEC.